### PR TITLE
grafana add summary feedback store

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -1,0 +1,108 @@
+name: End to End Test
+
+on:
+  push:
+  pull_request:
+
+env:
+  LUNETTES_DOCKERHUB_REPO: local/lunettes
+
+jobs:
+  create-cluster:
+    runs-on: ubuntu-latest
+    steps:
+    # git checkout code
+    - name: Checkout
+      uses: actions/checkout@v2
+    # Use the git command to retrieve the current tag information and store it in the environment variable APP_VERSION.
+    - name: Generate App Version
+      run: echo APP_VERSION=`git describe --tags --always` >> $GITHUB_ENV
+    - name: Build lunettes
+      id: docker_build_lunettes
+      uses: docker/build-push-action@v2
+      with:
+        push: false
+        file: build/docker/Dockerfile.lunettes
+        # docker build arg
+        build-args: |
+          GOARCH=$(go env GOARCH)
+        # Generate two Docker tags: ${APP_VERSION}
+        tags: |
+          ${{ env.LUNETTES_DOCKERHUB_REPO }}:${{ env.APP_VERSION }}
+    - name: Create k8s Kind Cluster
+      uses: helm/kind-action@v1.5.0
+      with:
+        config: hack/kind.yaml
+        cluster_name: k8s
+    - name: Test kind
+      run: |
+        kubectl get ns
+    - name: kind load image
+      run: |
+        kind load docker-image --name k8s ${{ env.LUNETTES_DOCKERHUB_REPO }}:${{ env.APP_VERSION }}
+    - uses: azure/setup-helm@v3
+      id: install
+    - name: Deploy lunettes
+      run: |
+        helm upgrade --install lunettes deploy/helm/lunettes/ \
+          --set lunettesImage=${{ env.LUNETTES_DOCKERHUB_REPO }}:${{ env.APP_VERSION }} \
+          --set enableAuditApiserver=true \
+          --set lunettesType=NodePort \
+          --set grafanadiType=NodePort \
+          --set grafanaType=NodePort \
+          --set jaegerType=NodePort
+        # waiting for lunettes ready
+        set +e
+        for ((i=0; i<120; i++))
+        do
+          status=$(curl -s -XGET "http://localhost:9094/_cluster/health?pretty" | awk -F'"' '/"status"/{print $4}')
+          echo "status is $status"
+          if [ -n "$status" ] && [ "$status" != "red" ]; then
+              echo "Elasticsearch服务已准备就绪，状态为: $status"
+              break
+          else
+              echo "Elasticsearch服务未准备就绪，当前状态为: $status"
+          fi
+          output=$(kubectl -n lunettes get pods -owide)
+          echo "$output"
+          lunettes_pod_name=$(echo "$output" | awk '$1 ~ /^lunettes-/{print $1}')
+          echo -e "################# log lunettes ......#################\n"
+          kubectl -n lunettes logs $lunettes_pod_name | head -n 100
+          es_pod_name=$(echo "$output" | awk '$1 ~ /^es-single-/{print $1}')
+          echo -e "################# log es-single ...... #################\n"
+          kubectl -n lunettes logs $es_pod_name | head -n 100
+          sleep 1m
+        done
+        set -e
+    - name: Create test pod
+      run: |
+        kubectl run nginx --image=nginx
+        sleep 30
+        kubectl get pods
+        sleep 5m
+        echo "waiting for lunettes process audit"
+    - name: Test podinfo api with curl
+      run: |
+        response=$(curl -X GET "http://localhost:9099/podinfotable?searchkey=name&searchvalue=nginx")
+        if echo "$response" | grep -q "nginx"; then
+          echo "URL test passed"
+        else
+          echo "URL test failed"
+          exit 1
+        fi
+
+        response=$(curl -X GET "http://localhost:9099/podsummary?searchkey=name&searchvalue=nginx")
+        if echo "$response" | grep -q "Summary"; then
+          echo "summary test passed"
+        else
+          echo "summary test failed"
+          exit 1
+        fi
+
+        response=$(curl -X POST -H "Content-Type: application/json" -d '{"Feedback": "negative","Score": 1,"Comment": "Bad experience!","Summary": "Pod deliver successfully!"}' "http://localhost:9099/podsummaryfeedback?searchkey=name&searchvalue=nginx")
+        if echo "$response" | grep -q "Feedback"; then
+          echo "feedback test passed"
+        else
+          echo "feedback test failed"
+          exit 1
+        fi

--- a/deploy/helm/lunettes/templates/grafana/grafana-cm.yaml
+++ b/deploy/helm/lunettes/templates/grafana/grafana-cm.yaml
@@ -654,83 +654,24 @@ data:
             "h": 10,
             "w": 13,
             "x": 0,
-            "y": 4
+            "y": 3
           },
           "id": 23,
           "options": {
-            "layout": {
-              "variant": "split",
-              "padding": 0,
-              "orientation": "horizontal",
-              "sections": [
-                {
-                  "id": "summary",
-                  "name": ""
-                },
-                {
-                  "id": "feedback",
-                  "name": ""
-                },
-                {
-                  "id": "",
-                  "name": ""
-                }
-              ]
-            },
-            "initial": {
-              "method": "query",
-              "contentType": "application/json",
-              "code": "console.log(data, response, initial, elements);\n\nreturn;\n\n/**\n * Data Source\n * Requires form elements to be defined\n */\nconst dataQuery = toDataQueryResponse(response);\nconsole.log(dataQuery);",
-              "getPayload": "return {\n  rawSql: '',\n  format: 'table',\n}",
-              "highlight": false,
-              "highlightColor": "red"
-            },
-            "update": {
-              "method": "-",
-              "contentType": "application/json",
-              "code": "// const payload = {};\n// elements.forEach((element) => {\n//   if (!element.value) {\n//     return;\n//   }\n//   payload[element.id] = element.value;\n// })\n// const url = 'http://localhost:9099/podsummaryfeedback?searchkey=name&searchvalue=nginx'\n// const store = {\n//   Feedback: payload.Feedback,\n//   Score: payload.Score,\n//   Comment: payload.Comment\n//   , Summary: payload.Summary\n// };\n\n// console.log(JSON.stringify(store))\n\n// fetch(url, {\n//   method: 'POST',\n//   headers: {\n//     'Content-Type': 'application/json'\n//   },\n//   body: JSON.stringify(store)\n// })\n//   .then(response => response.json())\n//   .then(data => {\n//     console.log(data);\n//   })\n//   .catch(error => {\n//     console.error('error:', error);\n//   }); ",
-              "payloadMode": "all",
-              "getPayload": "const payload = {};\n\nelements.forEach((element) => {\n  if (!element.value) {\n    return;\n  }\n\n  payload[element.id] = element.value;\n})\n\nreturn payload;\n\n/**\n * Data Source payload\n */ \nreturn {\n  rawSql: '',\n  format: 'table',\n};",
-              "confirm": false
-            },
-            "confirmModal": {
-              "title": "Confirm update request",
-              "body": "Please confirm to update changed values",
-              "columns": {
-                "name": "Label",
-                "oldValue": "Old Value",
-                "newValue": "New Value"
-              },
-              "confirm": "Confirm",
-              "cancel": "Cancel"
-            },
             "buttonGroup": {
               "orientation": "center",
               "size": "md"
             },
-            "submit": {
-              "variant": "custom",
-              "foregroundColor": "#fffefd",
-              "backgroundColor": "blue",
-              "icon": "cloud-upload",
-              "text": "Submit Feedback"
-            },
-            "reset": {
-              "variant": "hidden",
-              "foregroundColor": "yellow",
-              "backgroundColor": "purple",
-              "icon": "process",
-              "text": "Reset"
-            },
-            "resetAction": {
-              "mode": "custom",
-              "code": "if (response && response.ok) {\n  notifySuccess(['Update', 'Values updated successfully.']);\n  locationService.reload();\n} else {\n  notifyError(['Update', 'An error occured updating values.']);\n}",
-              "getPayload": "return {\n  rawSql: '',\n  format: 'table',\n}"
-            },
-            "saveDefault": {
-              "variant": "hidden",
-              "icon": "save",
-              "text": "Save Default"
+            "confirmModal": {
+              "body": "Please confirm to update changed values",
+              "cancel": "Cancel",
+              "columns": {
+                "name": "Label",
+                "newValue": "New Value",
+                "oldValue": "Old Value"
+              },
+              "confirm": "Confirm",
+              "title": "Confirm update request"
             },
             "elements": [
               {
@@ -805,7 +746,66 @@ data:
                 "unit": "",
                 "value": ""
               }
-            ]
+            ],
+            "initial": {
+              "code": "console.log(data, response, initial, elements);\n\nreturn;\n\n/**\n * Data Source\n * Requires form elements to be defined\n */\nconst dataQuery = toDataQueryResponse(response);\nconsole.log(dataQuery);",
+              "contentType": "application/json",
+              "getPayload": "return {\n  rawSql: '',\n  format: 'table',\n}",
+              "highlight": false,
+              "highlightColor": "red",
+              "method": "query"
+            },
+            "layout": {
+              "orientation": "horizontal",
+              "padding": 0,
+              "sections": [
+                {
+                  "id": "summary",
+                  "name": ""
+                },
+                {
+                  "id": "feedback",
+                  "name": ""
+                },
+                {
+                  "id": "",
+                  "name": ""
+                }
+              ],
+              "variant": "split"
+            },
+            "reset": {
+              "backgroundColor": "purple",
+              "foregroundColor": "yellow",
+              "icon": "process",
+              "text": "Reset",
+              "variant": "hidden"
+            },
+            "resetAction": {
+              "code": "if (response && response.ok) {\n  notifySuccess(['Update', 'Values updated successfully.']);\n  locationService.reload();\n} else {\n  notifyError(['Update', 'An error occured updating values.']);\n}",
+              "getPayload": "return {\n  rawSql: '',\n  format: 'table',\n}",
+              "mode": "custom"
+            },
+            "saveDefault": {
+              "icon": "save",
+              "text": "Save Default",
+              "variant": "hidden"
+            },
+            "submit": {
+              "backgroundColor": "blue",
+              "foregroundColor": "#fffefd",
+              "icon": "cloud-upload",
+              "text": "Submit Feedback",
+              "variant": "custom"
+            },
+            "update": {
+              "code": "const payload = {};\nelements.forEach((element) => {\n  if (!element.value) {\n    return;\n  }\n  payload[element.id] = element.value;\n})\nconst url = 'http://localhost:9099/podsummaryfeedback?searchkey=$podinfo&searchvalue=$podinfovalue'\nconst store = {\n  Feedback: payload.Feedback,\n  Score: payload.Score,\n  Comment: payload.Comment\n  , Summary: payload.Summary\n};\n\nconsole.log(JSON.stringify(store))\n\nfetch(url, {\n  method: 'POST',\n  headers: {\n    'Content-Type': 'application/json'\n  },\n  body: JSON.stringify(store)\n})\n  .then(response => response.json())\n  .then(data => {\n    console.log(data);\n  })\n  .catch(error => {\n    console.error('error:', error);\n  }); ",
+              "confirm": true,
+              "contentType": "application/json",
+              "getPayload": "const payload = {};\n\nelements.forEach((element) => {\n  if (!element.value) {\n    return;\n  }\n\n  payload[element.id] = element.value;\n})\n\nreturn payload;\n\n/**\n * Data Source payload\n */ \nreturn {\n  rawSql: '',\n  format: 'table',\n};",
+              "method": "-",
+              "payloadMode": "all"
+            }
           },
           "targets": [
             {

--- a/internal/grafanadi/handler/podsummary_feedback_handler.go
+++ b/internal/grafanadi/handler/podsummary_feedback_handler.go
@@ -1,0 +1,122 @@
+package handler
+
+import (
+	"time"
+	"net/http"
+	"encoding/json"
+	"fmt"
+
+	"github.com/alipay/container-observability-service/internal/grafanadi/model"
+	"github.com/alipay/container-observability-service/internal/grafanadi/service"
+	"github.com/alipay/container-observability-service/pkg/dal/storage-client/data_access"
+	storagemodel "github.com/alipay/container-observability-service/pkg/dal/storage-client/model"
+	"github.com/alipay/container-observability-service/pkg/utils"
+	interutils "github.com/alipay/container-observability-service/internal/grafanadi/utils"
+	"github.com/alipay/container-observability-service/pkg/metrics"
+)
+
+type PodSummaryFeedbackHandler struct {
+	request       *http.Request
+	writer        http.ResponseWriter
+	requestParams *PodSummaryFeedbackParams
+	storage       data_access.StorageInterface
+}
+
+type PodSummaryFeedbackParams struct {
+	PodUIDName string
+	PodUID     string
+	PodSummaryFeedback	 model.PodSummaryFeedback
+}
+
+func (handler *PodSummaryFeedbackHandler) RequestParams() interface{} {
+	return handler.requestParams
+}
+
+func (handler *PodSummaryFeedbackHandler) ParseRequest() error {
+	params := PodSummaryFeedbackParams{}
+	if handler.request.Method == http.MethodPost {
+		params.PodUIDName = handler.request.URL.Query().Get("searchkey")
+		params.PodUID = handler.request.URL.Query().Get("searchvalue")
+
+		var summaryFeedback model.PodSummaryFeedback
+		err := json.NewDecoder(handler.request.Body).Decode(&summaryFeedback)
+		if err != nil {
+			return err
+		}
+		params.PodSummaryFeedback = summaryFeedback
+	}
+	handler.requestParams = &params
+	return nil
+}
+
+func (handler *PodSummaryFeedbackHandler) ValidRequest() error {
+	return nil
+}
+
+func (handler *PodSummaryFeedbackHandler) StorePodSummaryFeedback(podUIDName string, podUID string, summaryFeedback model.PodSummaryFeedback) (int, interface{}, error) {
+	podInfos := make([]*storagemodel.PodInfo, 0)
+	podYamls := make([]*storagemodel.PodYaml, 0)
+	var podSummaryFeedback = storagemodel.PodSummaryFeedback{}
+	if podUID == "" {
+		return http.StatusOK, nil, nil
+	}
+
+	begin := time.Now()
+	podSummaryFeedback.CreateTime = begin
+	defer func() {
+		cost := utils.TimeSinceInMilliSeconds(begin)
+		metrics.QueryMethodDurationMilliSeconds.WithLabelValues("StorePodSummaryFeedback").Observe(cost)
+	}()
+	util := interutils.Util{
+		Storage: handler.storage,
+	}
+	util.GetUid(podYamls, podUIDName, &podUID)
+
+	errInfo := handler.storage.QueryPodInfoWithPodUid(&podInfos, podUID)
+	if errInfo != nil {
+		return http.StatusOK, nil, fmt.Errorf("QueryPodInfoWithPodUid error, error is %s", errInfo)
+	}
+	
+	if len(podInfos) > 0 {
+		info := podInfos[0]
+		podSummaryFeedback.ClusterName = info.ClusterName
+		podSummaryFeedback.Namespace = info.Namespace
+		podSummaryFeedback.PodName = info.PodName
+		podSummaryFeedback.PodUID = info.PodUID
+		podSummaryFeedback.PodIP = info.PodIP
+		podSummaryFeedback.NodeName = info.NodeName
+	}
+
+	podSummaryFeedback.Feedback = summaryFeedback.Feedback
+	podSummaryFeedback.Score = summaryFeedback.Score
+	podSummaryFeedback.Comment = summaryFeedback.Comment
+	podSummaryFeedback.Summary = summaryFeedback.Summary
+
+	errInfo = handler.storage.StorePodSummaryFeedbackWithPodUid(podSummaryFeedback, podSummaryFeedback)
+	if errInfo != nil {
+		return http.StatusOK, nil, fmt.Errorf("StorePodSummaryFeedbackWithPodUid error, error is %s", errInfo)
+	}
+
+	dataFrame := service.ConvertSummaryFeedback2Frame(podSummaryFeedback)
+	return http.StatusOK, dataFrame, nil
+}
+
+func (handler *PodSummaryFeedbackHandler) Process() (int, interface{}, error) {
+	var result interface{}
+	var err error
+	var httpStatus int
+
+	if handler.requestParams.PodUID != "" {
+		httpStatus, result, err = handler.StorePodSummaryFeedback(handler.requestParams.PodUIDName, handler.requestParams.PodUID, handler.requestParams.PodSummaryFeedback)
+	}
+
+	return httpStatus, result, err
+}
+
+func PodSummaryFeedbackFactory(w http.ResponseWriter, r *http.Request, storage data_access.StorageInterface) Handler {
+	return &PodSummaryFeedbackHandler{
+		request: r,
+		writer:  w,
+		storage: storage,
+	}
+}

--- a/internal/grafanadi/model/model.go
+++ b/internal/grafanadi/model/model.go
@@ -1,5 +1,7 @@
 package model
 
+import "time"
+
 // Take this as Example: https://sriramajeyam.com/grafana-infinity-datasource/wiki/json
 type BizInfoTable struct {
 	ClusterName string `json:"ClusterName,omitempty"`
@@ -165,4 +167,18 @@ type PodSummary struct {
 	ResultCode []string    `json:"ResultCode,omitempty"`
 	Component  interface{} `json:"Component,omitempty"`
 	Summary    interface{} `json:"Summary,omitempty"`
+}
+
+type PodSummaryFeedback struct {
+	ClusterName string    `json:"ClusterName,omitempty" gorm:"column:cluster_name"`
+	Namespace   string    `json:"Namespace,omitempty" gorm:"column:namespace"`
+	PodName     string    `json:"PodName,omitempty" gorm:"column:pod_name"`
+	PodUID      string    `json:"PodUID,omitempty" gorm:"column:pod_uid"`
+	PodIP       string    `json:"PodIP,omitempty" gorm:"column:pod_ip"`
+	NodeName    string    `json:"NodeName,omitempty" gorm:"-"`
+	Feedback    string    `json:"Feedback"`
+	Score       int       `json:"Score"`
+	Comment     string    `json:"Comment"`
+	Summary     string    `json:"Summary"`
+	CreateTime  time.Time `json:"CreateTime"`
 }

--- a/internal/grafanadi/service/podsummary_feedback.go
+++ b/internal/grafanadi/service/podsummary_feedback.go
@@ -1,0 +1,24 @@
+package service
+
+import (
+	"github.com/alipay/container-observability-service/internal/grafanadi/model"
+	storagemodel "github.com/alipay/container-observability-service/pkg/dal/storage-client/model"
+)
+
+func ConvertSummaryFeedback2Frame(summaryFeedback storagemodel.PodSummaryFeedback) []model.PodSummaryFeedback {
+	bit := model.PodSummaryFeedback{
+		ClusterName: summaryFeedback.ClusterName,
+		Namespace: summaryFeedback.Namespace,
+		PodName: summaryFeedback.PodName,
+		PodUID: summaryFeedback.PodUID,
+		PodIP: summaryFeedback.PodIP,
+		NodeName: summaryFeedback.NodeName,
+		Feedback: summaryFeedback.Feedback,
+		Score:   summaryFeedback.Score,
+		Comment: summaryFeedback.Comment,
+		Summary: summaryFeedback.Summary,
+		CreateTime: summaryFeedback.CreateTime,
+	}
+
+	return []model.PodSummaryFeedback{bit}
+}

--- a/pkg/dal/storage-client/data_access/mysql.go
+++ b/pkg/dal/storage-client/data_access/mysql.go
@@ -688,3 +688,6 @@ func (s *StorageSqlImpl) QueryPodYamlWithParams(data interface{}, debugparams *m
 	return nil
 
 }
+func (s *StorageSqlImpl) StorePodSummaryFeedbackWithPodUid(data interface{}, podSummaryFeedback model.PodSummaryFeedback) error {
+	return nil
+}

--- a/pkg/dal/storage-client/data_access/storage_interface.go
+++ b/pkg/dal/storage-client/data_access/storage_interface.go
@@ -58,6 +58,10 @@ type PodInfoInterface interface {
 	QueryPodInfoWithPodUid(data interface{}, uid string) error
 }
 
+type PodSummaryFeedbackInterface interface {
+	StorePodSummaryFeedbackWithPodUid(data interface{}, podSummaryFeedback model.PodSummaryFeedback) error
+}
+
 type StorageInterface interface {
 	AuditInterface
 	PodInterface
@@ -67,4 +71,5 @@ type StorageInterface interface {
 	PodLifePhaseInterface
 	SpanInterface
 	PodInfoInterface
+	PodSummaryFeedbackInterface
 }

--- a/pkg/dal/storage-client/model/podsummaryfeedback_model.go
+++ b/pkg/dal/storage-client/model/podsummaryfeedback_model.go
@@ -1,0 +1,30 @@
+package model
+
+import (
+	"time"
+)
+
+type PodSummaryFeedback struct {
+	ClusterName      string    `json:"ClusterName,omitempty" gorm:"column:cluster_name"`
+	Namespace        string    `json:"Namespace,omitempty" gorm:"column:namespace"`
+	PodName          string    `json:"PodName,omitempty" gorm:"column:pod_name"`
+	PodUID           string    `json:"PodUID,omitempty" gorm:"column:pod_uid"`
+	PodIP            string    `json:"PodIP,omitempty" gorm:"column:pod_ip"`
+	NodeName         string    `json:"NodeName,omitempty" gorm:"-"`
+	Feedback         string    `json:"Feedback"`
+	Score            int	   `json:"Score"`
+	Comment          string	   `json:"Comment"`
+	Summary			 string    `json:"Summary"`
+	CreateTime    	 time.Time `json:"CreateTime"`
+}
+
+func (s *PodSummaryFeedback) TableName() string {
+	return "pod_summary_feedback"
+}
+func (s *PodSummaryFeedback) EsTableName() string {
+	return "pod_summary_feedback"
+}
+
+func (s *PodSummaryFeedback) TypeName() string {
+	return "_doc"
+}

--- a/pkg/xsearch/xsearch.go
+++ b/pkg/xsearch/xsearch.go
@@ -650,6 +650,48 @@ const (
 			}
 		}
 	}`
+
+	podSummaryFeedbackIndexName = "pod_summary_feedback"
+	podSummaryFeedbackTypeName  = "_doc"
+	podSummaryFeedbackMapping   = `{
+		"mappings": {
+			"properties": {
+			  	"ClusterName": {
+					"type": "keyword"
+				},
+				"Namespace": {
+					"type": "keyword"
+				},
+				"PodName": {
+					"type": "keyword"
+				},
+				"PodUID": {
+					"type": "keyword"
+				},
+				"PodIP": {
+					"type": "keyword"
+				},
+				"NodeName": {
+					"type": "keyword"
+				},
+				"Feedback": {
+					"type": "keyword"
+				},
+				"Score": {
+					"type": "keyword"
+				},
+				"Comment": {
+					"type": "keyword"
+				},
+				"Summary": {
+					"type": "keyword"
+				},
+				"CreateTime": {
+					"type": "date"
+				}
+			}
+		}
+	}`
 )
 
 var esClient *elastic.Client
@@ -714,6 +756,13 @@ func InitZsearch(zsearchEndPoint, username, password string, extraInfo interface
 		log.Printf("index: %s, mammping: %s\n", auditStagingName, auditStagingMapping)
 		panic(err)
 	}
+
+	err = EnsureIndex(esClient, podSummaryFeedbackIndexName, podSummaryFeedbackMapping)
+	if err != nil {
+		log.Printf("index: %s, mammping: %s\n", podSummaryFeedbackIndexName, podSummaryFeedbackMapping)
+		panic(err)
+	}
+
 	err = EnsurePipeline(esClient, ztimePipelineName, ztimePipelineMapping)
 	if err != nil {
 		log.Printf("index: %s, mammping: %s\n", ztimePipelineName, ztimePipelineMapping)


### PR DESCRIPTION
solving issue #70

Added an interface “/podsummaryfeedback” to grafanadi, to collect user feedback on pod summary in grafana. Users can provide ratings and comments.

We add structure, table, index, and storage interface to the backend storage (in “elasticsearch.go/xsearch.go/storage_interface.go”). When the user clicks the submit feedback button, grafanadi first goes through the “podsummary_ feedback_ handler.go”. associates user feedback with current diagnostic information (pod information, pod summary), and then stores these information together in Elasticsearch.

Interface on Grafana
![image](https://github.com/alipay/container-observability-service/assets/43463041/3fe0559c-3299-4978-be84-220c4a08b32c)

Backend stored information
{
    ClusterName: 'staging',
    Namespace: 'default',
    PodName: 'nginx',
    PodUID: 'bd5b43ae-e155-4178-a312-41cda69bc0d2',
    PodIP: '10.244.1.77',
    Feedback: 'negative',
    Score: 1,
    Comment: 'Bad experience!',
    Summary: 'Pod deliver successfully!',
    CreateTime: '2024-01-22T08:17:44.202840511Z'
  }
