### PR TITLE
add grafanadi and lunettes-chart delay start

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -53,25 +53,38 @@ jobs:
           --set jaegerType=NodePort
         # waiting for lunettes ready
         set +e
+        all_pods=$(kubectl -n lunettes get pods -o jsonpath='{.items[*].metadata.name}')
+        echo "pods are: ${all_pods}"
         for ((i=0; i<120; i++))
         do
-          status=$(curl -s -XGET "http://localhost:9094/_cluster/health?pretty" | awk -F'"' '/"status"/{print $4}')
-          echo "status is $status"
-          if [ -n "$status" ] && [ "$status" != "red" ]; then
-              echo "Elasticsearch服务已准备就绪，状态为: $status"
+          all_pods_running=true
+          for pod in ${all_pods}
+          do
+            status=$(kubectl -n lunettes get pod ${pod} --output=jsonpath="{.status.phase}" )
+            if [ "${status}" != "Running" ]
+            then
+              all_pods_running=false
               break
-          else
-              echo "Elasticsearch服务未准备就绪，当前状态为: $status"
+            fi
+          done
+          if [ ${all_pods_running} = "true" ]
+          then
+            echo "all pods are running"
+            break
           fi
           output=$(kubectl -n lunettes get pods -owide)
           echo "$output"
-          lunettes_pod_name=$(echo "$output" | awk '$1 ~ /^lunettes-/{print $1}')
-          echo -e "################# log lunettes ......#################\n"
-          kubectl -n lunettes logs $lunettes_pod_name | head -n 100
-          es_pod_name=$(echo "$output" | awk '$1 ~ /^es-single-/{print $1}')
+          lunettes_pod_name=$(kubectl -n lunettes get pods | awk '$1 ~ /^lunettes-/{print $1}')
+          echo -e "################# log lunettes init ......#################\n"
+          kubectl -n lunettes logs ${lunettes_pod_name} -c init |head -n 100
+          grafanadi_pod_name=$(kubectl -n lunettes get pods | awk '$1 ~ /^grafanadi-/{print $1}')
+          echo -e "################# log grafanadi init ......#################\n"
+          kubectl -n lunettes logs ${grafanadi_pod_name} -c init |head -n 100
+          es_pod_name=$(kubectl -n lunettes get pods | awk '$1 ~ /^es-single-/{print $1}')
           echo -e "################# log es-single ...... #################\n"
-          kubectl -n lunettes logs $es_pod_name | head -n 100
-          sleep 1m
+          kubectl -n lunettes logs ${es_pod_name} | head -n 100
+          echo "rechecking the pod status after 30s..."
+          sleep 30
         done
         set -e
     - name: Create test pod

--- a/deploy/helm/lunettes/templates/grafanadi/grafanadi-deploy.yaml
+++ b/deploy/helm/lunettes/templates/grafanadi/grafanadi-deploy.yaml
@@ -18,6 +18,33 @@ spec:
         fsGroup: 472
         supplementalGroups:
           - 0
+      initContainers:
+      - command:
+        - bash
+        - -c
+        - |
+          echo "Waiting for Elasticsearch cluster to be ready..."
+          wait_time=1
+          # check es cluster health status
+          while true;
+          do
+            status=`curl -s -XGET --connect-timeout 3 --max-time 5 \
+            "http://es-cluster-svc.{{ .Values.namespace }}:9200/_cluster/health?pretty" \
+            | awk -F'"' '/"status"/{print $4}'`
+            if [ -n "${status}" ] && [ "${status}" != "red" ];
+            then
+              echo "Elasticsearch is healthy, status is: ${status}"
+              break
+            else
+              echo "Elasticsearch is unhealthy, status is: ${status}"
+              wait_time=$((wait_time+wait_time))
+              echo "Rechecking the status after ${wait_time}s..."
+              sleep ${wait_time}
+            fi
+          done
+        image: {{ .Values.lunettesImage }}
+        imagePullPolicy: {{ .Values.imagePullPolicy }}
+        name: init
       containers:
       - command:
         - ./grafanadi

--- a/deploy/helm/lunettes/templates/lunettes/lunettes-deploy.yaml
+++ b/deploy/helm/lunettes/templates/lunettes/lunettes-deploy.yaml
@@ -22,7 +22,27 @@ spec:
       - command:
         - bash
         - -c
-        - chown -R 500:500 /logs
+        - |
+          chown -R 500:500 /logs
+          echo "Waiting for Elasticsearch cluster to be ready..."
+          wait_time=1
+          # check es cluster health status
+          while true;
+          do
+            status=`curl -s -XGET --connect-timeout 3 --max-time 5 \
+            "http://es-cluster-svc.{{ .Values.namespace }}:9200/_cluster/health?pretty" \
+            | awk -F'"' '/"status"/{print $4}'`
+            if [ -n "${status}" ] && [ "${status}" != "red" ];
+            then
+              echo "Elasticsearch is healthy, status is: ${status}"
+              break
+            else
+              echo "Elasticsearch is unhealthy, status is: ${status}"
+              wait_time=$((wait_time+wait_time))
+              echo "Rechecking the status after ${wait_time}s..."
+              sleep ${wait_time}
+            fi
+          done
         image: {{ .Values.lunettesImage }}
         imagePullPolicy: {{ .Values.imagePullPolicy }}
         name: init


### PR DESCRIPTION
Before modification, grafanadi and lunettes-chart may restart due to slow readiness of the es cluster.
![test](https://github.com/alipay/container-observability-service/assets/91560756/478e46a0-392a-4609-ac74-9e203d66c20c)

After that, there will no longer be a restart, but wait for the es cluster to be ready before starting the service.
![test](https://github.com/alipay/container-observability-service/assets/91560756/fbd2b0b8-7675-4655-a608-a021fac59918)


Watch the output from the log，you can see the process of the components attempting to detect the status of the es cluster
![test](https://github.com/alipay/container-observability-service/assets/91560756/0b98844b-4a5e-428a-9565-251a6ad06ce7)


