### PR TITLE
refactor kubernetes env

### DIFF
--- a/deploy/helm/lunettes/templates/lunettes/lunettes-deploy.yaml
+++ b/deploy/helm/lunettes/templates/lunettes/lunettes-deploy.yaml
@@ -62,10 +62,14 @@ spec:
         env:
         - name: GOTRACEBACK
           value: crash
+{{- if .Values.kubernetesSvcHost }}
         - name: KUBERNETES_SERVICE_HOST
-          value: {{ .Values.kubernetesSvcHost }}
+          value: "{{ .Values.kubernetesSvcHost }}"
+{{- end }}
+{{- if .Values.kubernetesSvcPort }}
         - name: KUBERNETES_SERVICE_PORT
-          value: "6443"
+          value: "{{ .Values.kubernetesSvcPort }}"
+{{- end }}
         ports:
         - name: metrics
           containerPort: 9091

--- a/deploy/helm/lunettes/values.yaml
+++ b/deploy/helm/lunettes/values.yaml
@@ -5,7 +5,8 @@
 # share
 namespace: lunettes
 imagePullPolicy: IfNotPresent
-kubernetesSvcHost: kubernetes.default
+# kubernetesSvcHost: kubernetes.default
+# kubernetesSvcPort: "6443"
 cluster: staging
 esUser: elastic
 esPassword: changeme


### PR DESCRIPTION
Kubernetes does not guarantee that the API server has a valid certificate for the hostname kubernetes.default.svc; Users can specify custom apiserver host and port.