### PR TITLE
fix data exception

### DIFF
--- a/grafana_plugin/custom_log_panel/src/module.ts
+++ b/grafana_plugin/custom_log_panel/src/module.ts
@@ -6,6 +6,11 @@ import { SimpleEditor } from './components/SimpleEditor';
 export const plugin = new PanelPlugin<SimpleOptions>(SimplePanel).setPanelOptions((builder) => {
 
   return builder
+    .addStringArray({
+      path: 'params',
+      name: 'Variables',
+      defaultValue: ['podinfo', 'podinfovalue'],
+    })
     .addBooleanSwitch({
       path: 'showTime',
       name: 'Time',
@@ -55,7 +60,7 @@ export const plugin = new PanelPlugin<SimpleOptions>(SimplePanel).setPanelOption
     })
     .addRadio({
       path: 'dedupStrategy',
-      defaultValue: 'none',
+      defaultValue: 'signature',
       name: 'Deduplication',
       settings: {
         options: [

--- a/grafana_plugin/custom_log_panel/src/types.ts
+++ b/grafana_plugin/custom_log_panel/src/types.ts
@@ -17,4 +17,5 @@ export interface SimpleOptions {
   sortOrder: common.LogsSortOrder;
   wrapLogMessage: boolean;
   label: FieldConfig[];
+  params: string[]
 }


### PR DESCRIPTION
## Description
Fix the bug that data displayed on custom-log is inconsistent with the data returned from API

Some test example:
API's data:
![1711453108422-f5de9fd9-e1e2-46f6-9d05-31511ab6eb52](https://github.com/alipay/container-observability-service/assets/41713767/a355d8f6-7e99-436a-8042-62977115dc5e)
custom-log's data
![1711453218092-817435ca-5493-4554-9571-6b4fd3974bc3](https://github.com/alipay/container-observability-service/assets/41713767/7c92ea76-e22b-4a2c-99e7-ffa42a02d1ab)


## RelatedIssues
Close #104 
