### PR TITLE
Set plugin volkovlabs-form-panel's version to 3.1.0

### DIFF
--- a/.github/workflows/docker-helm.yml
+++ b/.github/workflows/docker-helm.yml
@@ -11,7 +11,7 @@ env:
   DOCKERHUB_LUNETTES_REPO: lunettes/lunettes
   DOCKERHUB_GRAFANA_REPO: lunettes/grafana
   # Plugins to be installed.
-  GRAFANA_PLUGINS: yesoreyeram-infinity-datasource marcusolsson-json-datasource marcusolsson-dynamictext-panel
+  GRAFANA_PLUGINS: yesoreyeram-infinity-datasource,marcusolsson-json-datasource,marcusolsson-dynamictext-panel,volkovlabs-form-panel 3.1.0
 
 
 jobs:

--- a/.github/workflows/docker-helm.yml
+++ b/.github/workflows/docker-helm.yml
@@ -11,7 +11,7 @@ env:
   DOCKERHUB_LUNETTES_REPO: lunettes/lunettes
   DOCKERHUB_GRAFANA_REPO: lunettes/grafana
   # Plugins to be installed.
-  GRAFANA_PLUGINS: yesoreyeram-infinity-datasource marcusolsson-json-datasource volkovlabs-form-panel marcusolsson-dynamictext-panel
+  GRAFANA_PLUGINS: yesoreyeram-infinity-datasource marcusolsson-json-datasource marcusolsson-dynamictext-panel
 
 
 jobs:

--- a/build/docker/Dockerfile.grafana
+++ b/build/docker/Dockerfile.grafana
@@ -20,12 +20,9 @@ COPY --from=node /app/yaml_panel/dist /var/lib/grafana/plugins/antgroup-yaml-pan
 COPY --from=node /app/custom_log_panel/dist /var/lib/grafana/plugins/antgroup-customlog-panel
 
 # Define the list of plugins to install, separated by spaces.
-ARG PLUGINS=""
+ARG PLUGINS="" IFS=','
 
 # Install each plugin.
 RUN for plugin in $PLUGINS; do \
       grafana-cli plugins install $plugin; \
     done
-
-# Install each plugin with custom version
-RUN grafana cli plugins install volkovlabs-form-panel 3.1.0 

--- a/build/docker/Dockerfile.grafana
+++ b/build/docker/Dockerfile.grafana
@@ -26,3 +26,6 @@ ARG PLUGINS=""
 RUN for plugin in $PLUGINS; do \
       grafana-cli plugins install $plugin; \
     done
+
+# Install each plugin with custom version
+RUN grafana cli plugins install volkovlabs-form-panel 3.1.0 


### PR DESCRIPTION
## Description
The latest version of volkovlabs-form-panel is 3.7.0, which is too heigh for current project.The most appropriate version is 3.1.0.

## Test Report
V3.7.0（before）
![1E496EBC-CB5A-4927-8D21-66974A6D2CA3](https://github.com/alipay/container-observability-service/assets/41713767/ef484ec0-93b4-4e02-b42f-01b4a0cddc59)

V3.1.0（after）
![0BA64D4F-CA19-49DA-8E63-0A80D9161177](https://github.com/alipay/container-observability-service/assets/41713767/ef1a4582-eb26-4eb8-b1da-c30bcaceb001)

##  RelatedIssues
Closed #106 